### PR TITLE
Update NoNestedIfStatementsRule to flag assignment + if pattern

### DIFF
--- a/src/Rules/NoNestedIfStatementsRule.php
+++ b/src/Rules/NoNestedIfStatementsRule.php
@@ -62,18 +62,18 @@ final class NoNestedIfStatementsRule implements Rule
         }
 
         $statementCount = count($node->stmts);
-        
+
         // Handle case 1: exactly one statement that is an if
         if (self::EXACTLY_ONE === $statementCount) {
             $statement = $node->stmts[0];
-            
+
             if (
                 !$statement instanceof If_ ||
                 self::ifHasElseIf($statement)
             ) {
                 return [];
             }
-            
+
             return [
                 RuleErrorBuilder::message(self::ERROR_MESSAGE)
                     ->identifier(self::IDENTIFIER)
@@ -81,12 +81,12 @@ final class NoNestedIfStatementsRule implements Rule
                     ->build(),
             ];
         }
-        
+
         // Handle case 2: exactly two statements where first is assignment and second is if
         if (self::EXACTLY_TWO === $statementCount) {
             $firstStatement = $node->stmts[0];
             $secondStatement = $node->stmts[1];
-            
+
             if (
                 !$firstStatement instanceof Expression ||
                 !$firstStatement->expr instanceof Assign ||
@@ -95,7 +95,7 @@ final class NoNestedIfStatementsRule implements Rule
             ) {
                 return [];
             }
-            
+
             return [
                 RuleErrorBuilder::message(self::ERROR_MESSAGE)
                     ->identifier(self::IDENTIFIER)
@@ -103,7 +103,7 @@ final class NoNestedIfStatementsRule implements Rule
                     ->build(),
             ];
         }
-        
+
         return [];
     }
 

--- a/tests/Rules/NoNestedIfStatementsRuleTest.php
+++ b/tests/Rules/NoNestedIfStatementsRuleTest.php
@@ -49,6 +49,7 @@ final class NoNestedIfStatementsRuleTest extends SingleRuleTestCase
     {
         $this->analyseExpectingErrorLines([__DIR__ . '/../Fixtures/NoNestedIf/complex_cases.php'], [
             25,
+            35, // assignment + if pattern
             70,
             82,
             92,


### PR DESCRIPTION
Expand the rule to detect nested if statements in two cases:
1. Existing: if contains exactly one nested if statement
2. New: if contains exactly one assignment followed by one if statement

This catches patterns like:
```
if (condition) {
    $var = getValue();
    if ($var \!== null) {
        // ...
    }
}
```